### PR TITLE
Better optimize final binary search guesses in Ben contender

### DIFF
--- a/lib/guess_who/contenders/ben.ex
+++ b/lib/guess_who/contenders/ben.ex
@@ -22,22 +22,19 @@ defmodule GuessWho.Contenders.Ben do
     |> guess()
   end
 
-  # Final turn: We had two options last turn and guessed one of them - it was wrong - guess the other
-  def turn({:name_guessed?, false}, name), do: {name, nil}
+  # Final turns: We had two or three options last turn and guessed one of them - it was wrong - guess another
+  def turn({:name_guessed?, false}, {name, names}), do: guess(names -- [name])
 
-  # There are two options left - guess one of them and save the other one to guess next time
-  defp guess([a, b]), do: {a, b}
-
-  # There's only one option left - guess it
-  defp guess([name]), do: {name, nil}
-
-  # There's many options left - generate a regex that matches half of them and submit that
+  # Generate a regex that matches half of the remaining options and submit that
+  # If "half" can be reasonably interpretted as a single name, directly guess that name instead of submitting a regex
   defp guess(chars) do
     r = regex_matching_everything_in(half_list(chars))
     {r, {r, chars}}
   end
 
+  defp regex_matching_everything_in([name]), do: name
   defp regex_matching_everything_in(list), do: Regex.compile!("^(#{Enum.join(list, "|")})$")
 
-  defp half_list(list), do: Enum.take(list, round(length(list) / 2))
+  defp half_list([name]), do: [name]
+  defp half_list(list), do: Enum.take(list, trunc(length(list) / 2))
 end


### PR DESCRIPTION
When using the name-regex-binary-search strategy, there's an optimization to be made in the final guesses, when there are two remaining possibilities. In a naive "submit a regex until there's only one remaining candidate" approach, you will often reach a point where there are two candidates remaining, so you submit a regex containing one name, and then pare the list down to the final candidate and guess it. But it is always better in that case to just directly guess a name, because you have a 50/50 shot of just getting it right that turn and otherwise you still guess the final candidate next turn (instead of always taking exactly two turns)

This particular optimization was already implemented, but it turns out the optimization also applies when there are _three_ remaining candidates as well. ie, it's better to directly guess a name when there are three candidates than it is to generate a regex matching against one or two of them. So the optimization rule can be generalized as "always guess a name if a single name can reasonably be considered half of the remaining candidates" where "reasonably considered to be half" means rounding in either direction for odd length lists (1 is reasonably considered half of 3). If you round down your half-list pivot point, you will naturally fall into this generalized optimization (a 3-length list will result in a 1-length "half", which would be caught and optimized as a direct guess). If you round up your half-list pivot point (as I was doing before this change), a 3-length list will result in a 2-length "half" and you miss out on part of the optimization unless you explicitly check for it.

So anyway, this change moves the optimization check to "when the regex-generator would generate a 1-name match" instead of "when the candidate pool has exactly 2 candidates left" and then also rounds list halves down instead of up to take advantage of this catch.